### PR TITLE
Fix: Repair sidebar active link highlighting

### DIFF
--- a/includes/admin_sidebar.php
+++ b/includes/admin_sidebar.php
@@ -1,36 +1,47 @@
 <?php
 // Admin sidebar
+$current_script_path = $_SERVER['SCRIPT_NAME'];
+$app_path_segment = parse_url(APP_URL, PHP_URL_PATH); // Should be '/seats'
+if ($app_path_segment === '/' || $app_path_segment === null) {
+    $app_path_segment = ''; // Adjust if APP_URL is just 'http://localhost'
+}
 ?>
 <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
     <div class="position-sticky pt-3">
         <ul class="nav flex-column">
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'index.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/index.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/index.php') || str_ends_with($current_script_path, $app_path_segment . '/admin/'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/index.php">
                     <i class="bi bi-speedometer2"></i> Dashboard
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'modules.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/modules.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/modules.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/modules.php">
                     <i class="bi bi-journal-text"></i> Modules
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'lessons.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/lessons.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/lessons.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/lessons.php">
                     <i class="bi bi-book"></i> Lessons
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'quizzes.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/quizzes.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/quizzes.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/quizzes.php">
                     <i class="bi bi-question-circle"></i> Quizzes
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'users.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/users.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/users.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/users.php">
                     <i class="bi bi-people"></i> Users
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'reports.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/reports.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/reports.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/reports.php">
                     <i class="bi bi-bar-chart"></i> Reports
                 </a>
             </li>
@@ -41,7 +52,8 @@
         </h6>
         <ul class="nav flex-column mb-2">
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'profile.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/profile.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/admin/profile.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/admin/profile.php">
                     <i class="bi bi-person-circle"></i> Profile
                 </a>
             </li>

--- a/includes/employee_sidebar.php
+++ b/includes/employee_sidebar.php
@@ -1,21 +1,29 @@
 <?php
 // Employee sidebar
+$current_script_path = $_SERVER['SCRIPT_NAME'];
+$app_path_segment = parse_url(APP_URL, PHP_URL_PATH);
+if ($app_path_segment === null || $app_path_segment === false || $app_path_segment === '/') {
+    $app_path_segment = ''; // Handle cases where APP_URL might not have a path or is just '/'
+}
 ?>
 <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
     <div class="position-sticky pt-3">
         <ul class="nav flex-column">
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'index.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/index.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/employee/index.php') || str_ends_with($current_script_path, $app_path_segment . '/employee/'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/index.php">
                     <i class="bi bi-speedometer2"></i> Dashboard
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'modules.php' || basename($_SERVER['PHP_SELF']) == 'module.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/modules.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/employee/modules.php') || str_ends_with($current_script_path, $app_path_segment . '/employee/module.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/modules.php">
                     <i class="bi bi-journal-text"></i> My Modules
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) == 'profile.php' ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/profile.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/employee/profile.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/profile.php">
                     <i class="bi bi-person-circle"></i> Profile
                 </a>
             </li>
@@ -26,7 +34,8 @@
         </h6>
         <ul class="nav flex-column mb-2">
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo APP_URL; ?>/employee/resources.php">
+                <?php $is_active = str_ends_with($current_script_path, $app_path_segment . '/employee/resources.php'); ?>
+                <a class="nav-link <?php echo $is_active ? 'active' : ''; ?>" href="<?php echo APP_URL; ?>/employee/resources.php">
                     <i class="bi bi-file-earmark-text"></i> Security Resources
                 </a>
             </li>


### PR DESCRIPTION
The 'active' class in the admin and employee sidebars was previously determined using `basename($_SERVER['PHP_SELF'])`. This method was not reliable, especially for index pages or when URLs might involve query parameters for routing different views under the same script.

This commit refactors the active link detection logic in:
- `includes/admin_sidebar.php`
- `includes/employee_sidebar.php`

The new logic uses `$_SERVER['SCRIPT_NAME']` and compares it against the full expected path derived from the link's `href` attribute and the `APP_URL`'s path segment.

Key changes:
- I introduced helper variables `$current_script_path` and `$app_path_segment` (derived from `APP_URL`) at the beginning of each sidebar file.
- I updated the condition for applying the 'active' class for each navigation link to use `str_ends_with()` comparing the current script path with the target link path.
- For dashboard/index links, the logic correctly accounts for accessing the directory itself (e.g., `/admin/`) or the specific index file (e.g., `/admin/index.php`).
- For the employee "My Modules" link, the logic retains the behavior of staying active for both `modules.php` and `module.php`.
- I ensured the logic for `$app_path_segment` correctly handles cases where `APP_URL` might not have a path component (e.g., root domain).

This change should ensure more accurate and reliable highlighting of the active navigation item in the sidebars for both admin and employee users.